### PR TITLE
Full definitions

### DIFF
--- a/specs/PendingCaseDetail.yaml
+++ b/specs/PendingCaseDetail.yaml
@@ -98,7 +98,7 @@ paths:
           description: Forbidden
         "404":
           description: NotFound
-  /v1/policies:
+  /v1/activity-statuses/policies:
     get:
       operationId: getPolicies
       summary: Retrieve policies


### PR DESCRIPTION
Updates applied out of 6/2 committee meeting.

Remove applicationNumber in favor of applicationOriginId
Add senderParticipantId as optional header
Add receiverParticipantId as optional header
Add brokerNumber as optional header
Re-implement Scott's pathing for.../v1/activity-status/policies as scope of activity status is for pending cases