### PR TITLE
Updated the Style-Guide repo links and removed the draft spec 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Application Status
 
-IRI's Application Status API standards
+## IRI's Application Status API standards
 
-The OpenAPI specifications can be found at [api.irionline.org](https://api.irionline.org), which is the published GitHub Page of the [Digital-First-Specifications](https://github.com/Insured-Retirement-Institute/Digital-First-Specifications) repository.
+The business focused documentation can be found at [Applilcation Status](https://view.monday.com/18200990346-4e47baa487382177557c30e6c1ca6fff?r=use1)
+
+The OpenAPI specifications can be found at [specs.dfa.irionline.org](https://specs.dfa.irionline.org/), which is the published GitHub Page of the [Digital-First-Specifications](https://github.com/Insured-Retirement-Institute/Digital-First-Specifications) repository.

--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 IRI's Application Status API standards
 
-Definition can be found at [/specs/ApplicationStatus.yaml](https://github.com/Insured-Retirement-Institute/Application-Status/blob/main/specs/ApplicationStatus.yaml) as well as the [GitHub Page](https://insured-retirement-institute.github.io/Style-Guide/) of the Style Guide repoistory.
+The OpenAPI specifications can be found at [api.irionline.org](https://api.irionline.org), which is the published GitHub Page of the [Digital-First-Specifications](https://github.com/Insured-Retirement-Institute/Digital-First-Specifications) repository.


### PR DESCRIPTION
As part of the rename of the [Style-Guide](https://github.com/Insured-Retirement-Institute/Style-Guide) repo to [Digital-First-Specifications](https://github.com/Insured-Retirement-Institute/Digital-First-Specifications), a few changes to the README were needed:
* Fixing the link to the repo
* Fixing the link to the published GitHub Page to be [specs.dfa.irionline.org](https://specs.dfa.irionline.org/) (which is the new URL after the repo was renamed)

While changing the README, I also removed the reference to the draft spec since the Application-Status spec is now officially kept in the [Digital-First-Specifications](https://github.com/Insured-Retirement-Institute/Digital-First-Specifications) repo

Lastly, I added a link to the business documentation on [monday.com](https://view.monday.com/18200990346-4e47baa487382177557c30e6c1ca6fff?r=use1), but I'm happy to remove it if that's not appropriate.

**OLD README**
<img width="912" height="258" alt="image" src="https://github.com/user-attachments/assets/876e5bfd-538e-4160-98ff-0532a4b34a8e" />

**NEW README**
<img width="905" height="340" alt="image" src="https://github.com/user-attachments/assets/fee69838-acbb-42bb-a32a-5c0fd4f9bc4f" />
